### PR TITLE
Update to latest Azure Provider APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,12 @@ module "dcos-lbs" {
 |------|-------------|:----:|:-----:|:-----:|
 | additional_rules | List of additional rules | string | `<list>` | no |
 | cluster_name | Name of the DC/OS cluster | string | - | yes |
+| instance_nic_ids | List of instance nic ids created by this module | list | - | yes |
 | internal | This ELB is internal only | string | `false` | no |
+| ip_configuration_names | List of ip configuration names associated with the instance nic ids | list | - | yes |
 | lb_name_format | Printf style format for naming the LB. (input cluster_name) | string | `lb-%[1]s` | no |
 | location | Azure Region | string | - | yes |
+| num | How many instances should be created | string | - | yes |
 | probe | Main probe to check for node health | map | `<map>` | no |
 | resource_group_name | Name of the azure resource group | string | - | yes |
 | rules | List of rules. By default HTTP and HTTPS are set. If set it overrides the default rules. | string | `<list>` | no |

--- a/main.tf
+++ b/main.tf
@@ -82,6 +82,13 @@ resource "azurerm_lb_backend_address_pool" "backend_pool" {
   loadbalancer_id     = "${azurerm_lb.load_balancer.id}"
 }
 
+resource "azurerm_network_interface_backend_address_pool_association" "this" {
+  count                   = "${var.num}"
+  network_interface_id    = "${element(var.instance_nic_ids, count.index)}"
+  ip_configuration_name   = "${element(var.ip_configuration_names, count.index)}"
+  backend_address_pool_id = "${azurerm_lb_backend_address_pool.backend_pool.id}"
+}
+
 # Load Balancer Rule
 resource "azurerm_lb_rule" "load_balancer_rule" {
   count               = "${length(local.final_rules)}"

--- a/main.tf
+++ b/main.tf
@@ -49,12 +49,12 @@ locals {
 }
 
 resource "azurerm_public_ip" "public_ip" {
-  count                        = "${var.internal ? 0 : 1}"
-  name                         = "${local.lb_name}-ip"
-  location                     = "${var.location}"
-  resource_group_name          = "${var.resource_group_name}"
-  public_ip_address_allocation = "dynamic"
-  domain_name_label            = "${local.lb_name}-ip"
+  count               = "${var.internal ? 0 : 1}"
+  name                = "${local.lb_name}-ip"
+  location            = "${var.location}"
+  resource_group_name = "${var.resource_group_name}"
+  allocation_method   = "Dynamic"
+  domain_name_label   = "${local.lb_name}-ip"
 
   tags = "${local.merged_tags}"
 }
@@ -68,7 +68,7 @@ resource "azurerm_lb" "load_balancer" {
   frontend_ip_configuration {
     name                          = "${local.lb_name}-public-ip-config"
     public_ip_address_id          = "${var.internal ? "" : element(concat(azurerm_public_ip.public_ip.*.id,list("")),0)}"
-    private_ip_address_allocation = "dynamic"
+    private_ip_address_allocation = "Dynamic"
     subnet_id                     = "${var.internal ? var.subnet_id : ""}"
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,16 @@ variable "lb_name_format" {
   default     = "lb-%[1]s"
 }
 
+variable "instance_nic_ids" {
+  description = "List of instance nic ids created by this module"
+  type        = "list"
+}
+
+variable "ip_configuration_names" {
+  description = "List of ip configuration names associated with the instance nic ids"
+  type        = "list"
+}
+
 # Name of the azure resource group
 variable "resource_group_name" {
   description = "Name of the azure resource group"
@@ -16,6 +26,11 @@ variable "resource_group_name" {
 # Location (region)
 variable "location" {
   description = "Azure Region"
+}
+
+# Number of Instance
+variable "num" {
+  description = "How many instances should be created"
 }
 
 variable "tags" {


### PR DESCRIPTION
https://jira.mesosphere.com/browse/DCOS-49945

Azure has deprecated some of their api and requires universal installer updates in order for us to continue to use these changes. Whenever there is a new resource introduced into the templates, this is considered a breaking change to our definition and requires an update to a minor version of the universal installer.

There is a limitation/workaround here that was used within these 0.2 change that will be updated when terraform v0.12.0 is released.

The issue is located here: `https://github.com/hashicorp/terraform/issues/12570`